### PR TITLE
docs: update link to Otterdog list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,4 @@ This repository hosts configurations for GitHub organizations managed and mainta
 
 List of otterdog enabled GitHub orgs:
 
-https://eclipsefdn.github.io/otterdog-configs/
-
+https://otterdog.eclipse.org/


### PR DESCRIPTION
Currently the link on the README to https://eclipsefdn.github.io/otterdog-configs/,  mentions that current page is deprecated
<img width="1376" alt="image" src="https://github.com/user-attachments/assets/66288899-8197-460d-a87f-ea340453369d">

and suggests directly visiting https://otterdog.eclipse.org, as such I'm proposing to update the README to have the most up-to-date page linked.