### PR TITLE
Reenable eclipse-arche organization

### DIFF
--- a/otterdog.json
+++ b/otterdog.json
@@ -1162,6 +1162,10 @@
     {
       "name": "iot.oscat",
       "github_id": "eclipse-oscat"
+    },
+    {
+      "name": "automotive.arche",
+      "github_id": "eclipse-arche"
     }
   ]
 }


### PR DESCRIPTION
The eclipse-arche organization was recently removed, [see](https://github.com/EclipseFdn/otterdog-configs/commit/e4afba0e196afc59d4da399dc1dc84d1ab3004f1).

The project is now active and therefore we need to enable Otterdog to be able to configure our organization, [see](https://github.com/EclipseFdn/otterdog-configs/issues/142).