### PR TITLE
Update vulnerability reporting channels in otterdog blueprint

### DIFF
--- a/blueprints/default-security-policy.yml
+++ b/blueprints/default-security-policy.yml
@@ -19,10 +19,9 @@ config:
         
         **Please do not report security vulnerabilities through public issues, discussions, or pull requests.**
         
-        Instead, report it using one of the following ways:
+        Instead, report it by:
 
-        * Contact the [Eclipse Foundation Security Team](mailto:security@eclipse-foundation.org) via email
-        * Create a [confidential issue](https://gitlab.eclipse.org/security/vulnerability-reports/-/issues/new?issuable_template=new_vulnerability) in the Eclipse Foundation Vulnerability Reporting Tracker
+        * Creating a [confidential issue](https://gitlab.eclipse.org/security/vulnerability-reports/-/issues/new?issuable_template=new_vulnerability) in the Eclipse Foundation Vulnerability Reporting Tracker
         
         You can find more information about reporting and disclosure at the [Eclipse Foundation Security page](https://www.eclipse.org/security/).
 


### PR DESCRIPTION
We're removing the security email address as a valid channel for reporting vulnerabilities. This decision comes in response to a sharp increase in report volume, particularly a growing share of low-effort and automated, AI-generated submissions. To manage this load more effectively, we'll be concentrating our efforts on the two remaining channels: the GitLab issue tracker and GitHub private advisories. An official announcement will follow shortly.